### PR TITLE
PXP-7805 Fetch audit logs from an AWS SQS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: git@github.com:Yelp/detect-secrets
-    rev: v1.0.3
+    rev: v0.13.1
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,9 @@
 {
-  "generated_at": "2021-02-25T23:24:34Z",
+  "exclude": {
+    "files": "poetry.lock",
+    "lines": null
+  },
+  "generated_at": "2021-05-10T21:15:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8,8 +12,8 @@
       "name": "ArtifactoryDetector"
     },
     {
-      "name": "Base64HighEntropyString",
-      "limit": 4.5
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
     },
     {
       "name": "BasicAuthDetector"
@@ -18,8 +22,8 @@
       "name": "CloudantDetector"
     },
     {
-      "name": "HexHighEntropyString",
-      "limit": 3
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
     },
     {
       "name": "IbmCloudIamDetector"
@@ -56,55 +60,24 @@
   "results": {
     ".github/workflows/ci.yaml": [
       {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/ci.yaml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 14
+        "line_number": 14,
+        "type": "Secret Keyword"
       }
     ],
     "tests/test-audit-service-config.yaml": [
       {
-        "type": "Secret Keyword",
-        "filename": "tests/test-audit-service-config.yaml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 10
+        "line_number": 11,
+        "type": "Secret Keyword"
       }
     ]
   },
-  "version": "1.0.3",
-  "filters_used": [
-    {
-      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_sequential_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": [
-        "poetry.lock"
-      ]
-    }
-  ]
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "poetry.lock",
     "lines": null
   },
-  "generated_at": "2021-05-10T21:15:11Z",
+  "generated_at": "2021-05-19T17:50:55Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,7 @@
       {
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 11,
+        "line_number": 10,
         "type": "Secret Keyword"
       }
     ]

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ The server is built with [FastAPI](https://fastapi.tiangolo.com/) and packaged w
 * [Deploying the Audit Service to a Gen3 Data Commons](docs/how-to/deployment.md)
 * [Architecture](docs/reference/architecture.md)
 * [Query response page size](docs/explanation/query_page_size.md)
-* [Async POST endpoint](docs/explanation/async_post.md)
+* [Creating audit logs](docs/explanation/creating_audit_logs.md)
 * [How to add a new audit log category?](docs/how-to/add_log_category.md)

--- a/docs/explanation/async_post.md
+++ b/docs/explanation/async_post.md
@@ -1,7 +1,0 @@
-# Async POST endpoint
-
-This is an async endpoint:
-- POSTing audit logs does not impact the performance of the caller.
-- Audit Service failures are not visible to users (for example, we don’t want to return a 500 error to users who are trying to download).
-
-How to alert the team if for some reason (bug, full DB) we’re not recording audit logs anymore? TODO (PXP-7805)

--- a/docs/explanation/creating_audit_logs.md
+++ b/docs/explanation/creating_audit_logs.md
@@ -1,0 +1,13 @@
+# Creating audit logs
+
+## Async POST endpoint
+
+The audit log creation endpoints is an async endpoint:
+- POSTing audit logs does not impact the performance of the caller.
+- Audit Service failures are not visible to users (for example, we don’t want to return a 500 error to users who are trying to download).
+
+However, it's difficult to monitor errors when using this endpoints.
+
+## Pulling from a queue
+
+The audit service can also handle pulling audit logs from a queue, which allows for easier monitoring. This can be configured by turning on the `PULL_FROM_QUEUE` flag in the configuration file (enabled by default). Right now, only AWS SQS is integrated, but integrations for other types of queues can be added by adding code and extending the values accepted for the `QUEUE_CONFIG.type` field in the configuration file.

--- a/docs/explanation/creating_audit_logs.md
+++ b/docs/explanation/creating_audit_logs.md
@@ -6,7 +6,7 @@ The audit log creation endpoints is an async endpoint:
 - POSTing audit logs does not impact the performance of the caller.
 - Audit Service failures are not visible to users (for example, we don’t want to return a 500 error to users who are trying to download).
 
-However, it's difficult to monitor errors when using this endpoints.
+However, it's difficult to monitor errors when using this endpoint.
 
 ## Pulling from a queue
 

--- a/docs/how-to/deployment.md
+++ b/docs/how-to/deployment.md
@@ -9,6 +9,8 @@ ENABLE_AUDIT_LOGS:
   login: <true or false>
 ```
 
+The `PUSH_AUDIT_LOGS_CONFIG` field must also be configured. When using `type: aws_sqs`, the SQS URL and region can be copied from the Audit Service configuration. See the [default Fence configuration file](https://github.com/uc-cdis/fence/blob/master/fence/config-default.yaml) for more details.
+
 ## Notes
 
 1. When adding audit log creation in a service for the first time, the `audit-service` deployment file `network-ingress` annotation (see [here](https://github.com/uc-cdis/cloud-automation/blob/27770776d239bc609bbbd23607689cf62de1bc66/kube/services/audit-service/audit-service-deploy.yaml#L6)) must be updated to allow the service to talk to `audit-service`.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -73,7 +73,6 @@ components:
       - username
       - sub
       - guid
-      - resource_paths
       - action
       title: CreatePresignedUrlLogInput
       type: object

--- a/migrations/versions/fd0510a0a9aa_optional_presigned_url_resource_paths.py
+++ b/migrations/versions/fd0510a0a9aa_optional_presigned_url_resource_paths.py
@@ -1,0 +1,30 @@
+"""optional presigned_url resource_paths
+
+Revision ID: fd0510a0a9aa
+Revises: d5b18185c458
+Create Date: 2021-05-25 15:06:06.372742
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "fd0510a0a9aa"
+down_revision = "d5b18185c458"
+branch_labels = None
+depends_on = None
+
+
+table_name = "presigned_url"
+
+
+def upgrade():
+    op.alter_column(table_name, "resource_paths", nullable=True)
+
+
+def downgrade():
+    # replace null values with an empty array
+    op.execute(
+        f"UPDATE {table_name} SET resource_paths=ARRAY[]::VARCHAR[] WHERE resource_paths IS NULL"
+    )
+    op.alter_column(table_name, "resource_paths", nullable=False)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "alembic"
-version = "1.5.6"
+version = "1.5.8"
 description = "A database migration tool for SQLAlchemy."
 category = "main"
 optional = false
@@ -91,6 +91,35 @@ description = "Function decoration for backoff and retry"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "boto3"
+version = "1.17.55"
+description = "The AWS SDK for Python"
+category = "main"
+optional = false
+python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+botocore = ">=1.20.55,<1.21.0"
+jmespath = ">=0.7.1,<1.0.0"
+s3transfer = ">=0.4.0,<0.5.0"
+
+[[package]]
+name = "botocore"
+version = "1.20.55"
+description = "Low-level, data-driven core of boto 3."
+category = "main"
+optional = false
+python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+jmespath = ">=0.7.1,<1.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = ">=1.25.4,<1.27"
+
+[package.extras]
+crt = ["awscrt (==0.11.11)"]
 
 [[package]]
 name = "cached-property"
@@ -215,7 +244,7 @@ test = ["pytest (==5.4.3)", "pytest-cov (==2.10.0)", "pytest-asyncio (>=0.14.0,<
 
 [[package]]
 name = "gen3authz"
-version = "1.0.4"
+version = "1.0.5"
 description = "Gen3 authz client"
 category = "main"
 optional = false
@@ -276,15 +305,15 @@ starlette = ">=0.13.0,<0.14.0"
 
 [[package]]
 name = "gunicorn"
-version = "20.0.4"
+version = "20.1.0"
 description = "WSGI HTTP Server for UNIX"
 category = "main"
 optional = false
-python-versions = ">=3.4"
+python-versions = ">=3.5"
 
 [package.extras]
-eventlet = ["eventlet (>=0.9.7)"]
-gevent = ["gevent (>=0.13)"]
+eventlet = ["eventlet (>=0.24.1)"]
+gevent = ["gevent (>=1.4.0)"]
 setproctitle = ["setproctitle"]
 tornado = ["tornado (>=0.2)"]
 
@@ -408,6 +437,14 @@ MarkupSafe = ">=0.23"
 i18n = ["Babel (>=0.8)"]
 
 [[package]]
+name = "jmespath"
+version = "0.10.0"
+description = "JSON Matching Expressions"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "mako"
 version = "1.1.4"
 description = "A super-fast templating language that borrows the  best ideas from the existing templating languages."
@@ -520,7 +557,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pytest"
-version = "6.2.2"
+version = "6.2.3"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
@@ -626,6 +663,20 @@ python-versions = "*"
 idna2008 = ["idna"]
 
 [[package]]
+name = "s3transfer"
+version = "0.4.1"
+description = "An Amazon S3 Transfer Manager"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+botocore = ">=1.12.36,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
+
+[[package]]
 name = "six"
 version = "1.15.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -643,7 +694,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "sqlalchemy"
-version = "1.3.23"
+version = "1.3.24"
 description = "Database Abstraction Library"
 category = "main"
 optional = false
@@ -690,16 +741,16 @@ python-versions = "*"
 
 [[package]]
 name = "urllib3"
-version = "1.26.3"
+version = "1.26.4"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
-brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+brotli = ["brotlipy (>=0.6.0)"]
 
 [[package]]
 name = "uvicorn"
@@ -763,11 +814,12 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "bcea0315d08e9424cefac49c0b8c527b169e53eef1461be83e5a77a1610f4753"
+content-hash = "c149d8eb02ee7f8c8d869554b8081f73c32ccb000b21d79664793b248cb24ecd"
 
 [metadata.files]
 alembic = [
-    {file = "alembic-1.5.6.tar.gz", hash = "sha256:8a8ccd58a262b1e3ac79b7224d0f9a4ac3bf96ace149972feb3ef9d7a06ac8b5"},
+    {file = "alembic-1.5.8-py2.py3-none-any.whl", hash = "sha256:8a259f0a4c8b350b03579d77ce9e810b19c65bf0af05f84efb69af13ad50801e"},
+    {file = "alembic-1.5.8.tar.gz", hash = "sha256:e27fd67732c97a1c370c33169ef4578cf96436fa0e7dcfaeeef4a917d0737d56"},
 ]
 asyncpg = [
     {file = "asyncpg-0.22.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:ccd75cfb4710c7e8debc19516e2e1d4c9863cce3f7a45a3822980d04b16f4fdd"},
@@ -805,6 +857,14 @@ authutils = [
 backoff = [
     {file = "backoff-1.10.0-py2.py3-none-any.whl", hash = "sha256:5e73e2cbe780e1915a204799dba0a01896f45f4385e636bcca7a0614d879d0cd"},
     {file = "backoff-1.10.0.tar.gz", hash = "sha256:b8fba021fac74055ac05eb7c7bfce4723aedde6cd0a504e5326bcb0bdd6d19a4"},
+]
+boto3 = [
+    {file = "boto3-1.17.55-py2.py3-none-any.whl", hash = "sha256:5910c868c2cf0d30b6c9caed1d38a2b2c2c83e9713eadae0f43de4f42bfe863f"},
+    {file = "boto3-1.17.55.tar.gz", hash = "sha256:d0d1e8ca76a8e1b74f87a8324f97001d60bd8bbe6cca35a8e9e7b9abe5aa9ddb"},
+]
+botocore = [
+    {file = "botocore-1.20.55-py2.py3-none-any.whl", hash = "sha256:94a62f7f848b37757c3419193727e183bccdf5cb74167df30bafee5d8d649b7a"},
+    {file = "botocore-1.20.55.tar.gz", hash = "sha256:5632c129e6c1c1a15e273fd3ec6f4431490e99ec61b6cff833538f456202e833"},
 ]
 cached-property = [
     {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
@@ -947,8 +1007,8 @@ fastapi = [
     {file = "fastapi-0.61.2.tar.gz", hash = "sha256:9e0494fcbba98f85b8cc9b2606bb6b625246e1b12f79ca61f508b0b00843eca6"},
 ]
 gen3authz = [
-    {file = "gen3authz-1.0.4-py3-none-any.whl", hash = "sha256:3149efbede9a59a27288e141b31c19aed9539d0172d34acdb62498fc922f5986"},
-    {file = "gen3authz-1.0.4.tar.gz", hash = "sha256:329ea8d32bfa23f13a2d2fee598922965d506934400dd0ed4c0a4fedd9da29da"},
+    {file = "gen3authz-1.0.5-py3-none-any.whl", hash = "sha256:f610bfd1166361dc2d5bd41035cbb6e9997b064c0885cf43e05232366d4a0866"},
+    {file = "gen3authz-1.0.5.tar.gz", hash = "sha256:ff160385114e008484f468bf053bb0f3898441e610ec0f37dbbec63e419dcae2"},
 ]
 gen3config = [
     {file = "gen3config-0.1.8.tar.gz", hash = "sha256:33d49b7f291146be12651aa4abe4612e436c9068548c4eb309b7837fa8e48d3b"},
@@ -962,8 +1022,7 @@ gino-starlette = [
     {file = "gino_starlette-0.1.1-py3-none-any.whl", hash = "sha256:de6ec87168097a52668359c842e9e3be4d339423c7805c615377975a1a19cb6c"},
 ]
 gunicorn = [
-    {file = "gunicorn-20.0.4-py2.py3-none-any.whl", hash = "sha256:cd4a810dd51bf497552cf3f863b575dabd73d6ad6a91075b65936b151cbf4f9c"},
-    {file = "gunicorn-20.0.4.tar.gz", hash = "sha256:1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626"},
+    {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
 ]
 h11 = [
     {file = "h11-0.9.0-py2.py3-none-any.whl", hash = "sha256:4bc6d6a1238b7615b266ada57e0618568066f57dd6fa967d1290ec9309b2f2f1"},
@@ -1018,6 +1077,10 @@ iniconfig = [
 jinja2 = [
     {file = "Jinja2-2.10.3-py2.py3-none-any.whl", hash = "sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f"},
     {file = "Jinja2-2.10.3.tar.gz", hash = "sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"},
+]
+jmespath = [
+    {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
+    {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
 ]
 mako = [
     {file = "Mako-1.1.4.tar.gz", hash = "sha256:17831f0b7087c313c0ffae2bcbbd3c1d5ba9eeac9c38f2eb7b50e8c99fe9d5ab"},
@@ -1140,8 +1203,8 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-6.2.2-py3-none-any.whl", hash = "sha256:b574b57423e818210672e07ca1fa90aaf194a4f63f3ab909a2c67ebb22913839"},
-    {file = "pytest-6.2.2.tar.gz", hash = "sha256:9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9"},
+    {file = "pytest-6.2.3-py3-none-any.whl", hash = "sha256:6ad9c7bdf517a808242b998ac20063c41532a570d088d77eec1ee12b0b5574bc"},
+    {file = "pytest-6.2.3.tar.gz", hash = "sha256:671238a46e4df0f3498d1c3270e5deb9b32d25134c99b7d75370a68cfbe9b634"},
 ]
 pytest-asyncio = [
     {file = "pytest-asyncio-0.14.0.tar.gz", hash = "sha256:9882c0c6b24429449f5f969a5158b528f39bde47dc32e85b9f0403965017e700"},
@@ -1193,6 +1256,10 @@ rfc3986 = [
     {file = "rfc3986-1.4.0-py2.py3-none-any.whl", hash = "sha256:af9147e9aceda37c91a05f4deb128d4b4b49d6b199775fd2d2927768abdc8f50"},
     {file = "rfc3986-1.4.0.tar.gz", hash = "sha256:112398da31a3344dc25dbf477d8df6cb34f9278a94fee2625d89e4514be8bb9d"},
 ]
+s3transfer = [
+    {file = "s3transfer-0.4.1-py2.py3-none-any.whl", hash = "sha256:b5130849df909773254099d085790456665f8d7e0032bbef6e3407f28adb1ad9"},
+    {file = "s3transfer-0.4.1.tar.gz", hash = "sha256:81b7b3516739b0cfbecaa9077a1baf783e7a790c0e49261fcc6ceda468765efa"},
+]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
@@ -1202,44 +1269,40 @@ sniffio = [
     {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
 ]
 sqlalchemy = [
-    {file = "SQLAlchemy-1.3.23-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:fd3b96f8c705af8e938eaa99cbd8fd1450f632d38cad55e7367c33b263bf98ec"},
-    {file = "SQLAlchemy-1.3.23-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:29cccc9606750fe10c5d0e8bd847f17a97f3850b8682aef1f56f5d5e1a5a64b1"},
-    {file = "SQLAlchemy-1.3.23-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:927ce09e49bff3104459e1451ce82983b0a3062437a07d883a4c66f0b344c9b5"},
-    {file = "SQLAlchemy-1.3.23-cp27-cp27m-win32.whl", hash = "sha256:b4b0e44d586cd64b65b507fa116a3814a1a53d55dce4836d7c1a6eb2823ff8d1"},
-    {file = "SQLAlchemy-1.3.23-cp27-cp27m-win_amd64.whl", hash = "sha256:6b8b8c80c7f384f06825612dd078e4a31f0185e8f1f6b8c19e188ff246334205"},
-    {file = "SQLAlchemy-1.3.23-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:9e9c25522933e569e8b53ccc644dc993cab87e922fb7e142894653880fdd419d"},
-    {file = "SQLAlchemy-1.3.23-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:a0e306e9bb76fd93b29ae3a5155298e4c1b504c7cbc620c09c20858d32d16234"},
-    {file = "SQLAlchemy-1.3.23-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:6c9e6cc9237de5660bcddea63f332428bb83c8e2015c26777281f7ffbd2efb84"},
-    {file = "SQLAlchemy-1.3.23-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:94f667d86be82dd4cb17d08de0c3622e77ca865320e0b95eae6153faa7b4ecaf"},
-    {file = "SQLAlchemy-1.3.23-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:751934967f5336a3e26fc5993ccad1e4fee982029f9317eb6153bc0bc3d2d2da"},
-    {file = "SQLAlchemy-1.3.23-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:63677d0c08524af4c5893c18dbe42141de7178001360b3de0b86217502ed3601"},
-    {file = "SQLAlchemy-1.3.23-cp35-cp35m-win32.whl", hash = "sha256:ddfb511e76d016c3a160910642d57f4587dc542ce5ee823b0d415134790eeeb9"},
-    {file = "SQLAlchemy-1.3.23-cp35-cp35m-win_amd64.whl", hash = "sha256:040bdfc1d76a9074717a3f43455685f781c581f94472b010cd6c4754754e1862"},
-    {file = "SQLAlchemy-1.3.23-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:d1a85dfc5dee741bf49cb9b6b6b8d2725a268e4992507cf151cba26b17d97c37"},
-    {file = "SQLAlchemy-1.3.23-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:639940bbe1108ac667dcffc79925db2966826c270112e9159439ab6bb14f8d80"},
-    {file = "SQLAlchemy-1.3.23-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:e8a1750b44ad6422ace82bf3466638f1aa0862dbb9689690d5f2f48cce3476c8"},
-    {file = "SQLAlchemy-1.3.23-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:e5bb3463df697279e5459a7316ad5a60b04b0107f9392e88674d0ece70e9cf70"},
-    {file = "SQLAlchemy-1.3.23-cp36-cp36m-win32.whl", hash = "sha256:e273367f4076bd7b9a8dc2e771978ef2bfd6b82526e80775a7db52bff8ca01dd"},
-    {file = "SQLAlchemy-1.3.23-cp36-cp36m-win_amd64.whl", hash = "sha256:ac2244e64485c3778f012951fdc869969a736cd61375fde6096d08850d8be729"},
-    {file = "SQLAlchemy-1.3.23-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:23927c3981d1ec6b4ea71eb99d28424b874d9c696a21e5fbd9fa322718be3708"},
-    {file = "SQLAlchemy-1.3.23-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d90010304abb4102123d10cbad2cdf2c25a9f2e66a50974199b24b468509bad5"},
-    {file = "SQLAlchemy-1.3.23-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a8bfc1e1afe523e94974132d7230b82ca7fa2511aedde1f537ec54db0399541a"},
-    {file = "SQLAlchemy-1.3.23-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:269990b3ab53cb035d662dcde51df0943c1417bdab707dc4a7e4114a710504b4"},
-    {file = "SQLAlchemy-1.3.23-cp37-cp37m-win32.whl", hash = "sha256:fdd2ed7395df8ac2dbb10cefc44737b66c6a5cd7755c92524733d7a443e5b7e2"},
-    {file = "SQLAlchemy-1.3.23-cp37-cp37m-win_amd64.whl", hash = "sha256:6a939a868fdaa4b504e8b9d4a61f21aac11e3fecc8a8214455e144939e3d2aea"},
-    {file = "SQLAlchemy-1.3.23-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:24f9569e82a009a09ce2d263559acb3466eba2617203170e4a0af91e75b4f075"},
-    {file = "SQLAlchemy-1.3.23-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2578dbdbe4dbb0e5126fb37ffcd9793a25dcad769a95f171a2161030bea850ff"},
-    {file = "SQLAlchemy-1.3.23-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:1fe5d8d39118c2b018c215c37b73fd6893c3e1d4895be745ca8ff6eb83333ed3"},
-    {file = "SQLAlchemy-1.3.23-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:c7dc052432cd5d060d7437e217dd33c97025287f99a69a50e2dc1478dd610d64"},
-    {file = "SQLAlchemy-1.3.23-cp38-cp38-win32.whl", hash = "sha256:ecce8c021894a77d89808222b1ff9687ad84db54d18e4bd0500ca766737faaf6"},
-    {file = "SQLAlchemy-1.3.23-cp38-cp38-win_amd64.whl", hash = "sha256:37b83bf81b4b85dda273aaaed5f35ea20ad80606f672d94d2218afc565fb0173"},
-    {file = "SQLAlchemy-1.3.23-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:8be835aac18ec85351385e17b8665bd4d63083a7160a017bef3d640e8e65cadb"},
-    {file = "SQLAlchemy-1.3.23-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6ec1044908414013ebfe363450c22f14698803ce97fbb47e53284d55c5165848"},
-    {file = "SQLAlchemy-1.3.23-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:eab063a70cca4a587c28824e18be41d8ecc4457f8f15b2933584c6c6cccd30f0"},
-    {file = "SQLAlchemy-1.3.23-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:baeb451ee23e264de3f577fee5283c73d9bbaa8cb921d0305c0bbf700094b65b"},
-    {file = "SQLAlchemy-1.3.23-cp39-cp39-win32.whl", hash = "sha256:94208867f34e60f54a33a37f1c117251be91a47e3bfdb9ab8a7847f20886ad06"},
-    {file = "SQLAlchemy-1.3.23-cp39-cp39-win_amd64.whl", hash = "sha256:f4d972139d5000105fcda9539a76452039434013570d6059993120dc2a65e447"},
-    {file = "SQLAlchemy-1.3.23.tar.gz", hash = "sha256:6fca33672578666f657c131552c4ef8979c1606e494f78cd5199742dfb26918b"},
+    {file = "SQLAlchemy-1.3.24-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:87a2725ad7d41cd7376373c15fd8bf674e9c33ca56d0b8036add2d634dba372e"},
+    {file = "SQLAlchemy-1.3.24-cp27-cp27m-win32.whl", hash = "sha256:f597a243b8550a3a0b15122b14e49d8a7e622ba1c9d29776af741f1845478d79"},
+    {file = "SQLAlchemy-1.3.24-cp27-cp27m-win_amd64.whl", hash = "sha256:fc4cddb0b474b12ed7bdce6be1b9edc65352e8ce66bc10ff8cbbfb3d4047dbf4"},
+    {file = "SQLAlchemy-1.3.24-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:f1149d6e5c49d069163e58a3196865e4321bad1803d7886e07d8710de392c548"},
+    {file = "SQLAlchemy-1.3.24-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:14f0eb5db872c231b20c18b1e5806352723a3a89fb4254af3b3e14f22eaaec75"},
+    {file = "SQLAlchemy-1.3.24-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:e98d09f487267f1e8d1179bf3b9d7709b30a916491997137dd24d6ae44d18d79"},
+    {file = "SQLAlchemy-1.3.24-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:fc1f2a5a5963e2e73bac4926bdaf7790c4d7d77e8fc0590817880e22dd9d0b8b"},
+    {file = "SQLAlchemy-1.3.24-cp35-cp35m-win32.whl", hash = "sha256:f3c5c52f7cb8b84bfaaf22d82cb9e6e9a8297f7c2ed14d806a0f5e4d22e83fb7"},
+    {file = "SQLAlchemy-1.3.24-cp35-cp35m-win_amd64.whl", hash = "sha256:0352db1befcbed2f9282e72843f1963860bf0e0472a4fa5cf8ee084318e0e6ab"},
+    {file = "SQLAlchemy-1.3.24-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:2ed6343b625b16bcb63c5b10523fd15ed8934e1ed0f772c534985e9f5e73d894"},
+    {file = "SQLAlchemy-1.3.24-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:34fcec18f6e4b24b4a5f6185205a04f1eab1e56f8f1d028a2a03694ebcc2ddd4"},
+    {file = "SQLAlchemy-1.3.24-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:e47e257ba5934550d7235665eee6c911dc7178419b614ba9e1fbb1ce6325b14f"},
+    {file = "SQLAlchemy-1.3.24-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:816de75418ea0953b5eb7b8a74933ee5a46719491cd2b16f718afc4b291a9658"},
+    {file = "SQLAlchemy-1.3.24-cp36-cp36m-win32.whl", hash = "sha256:26155ea7a243cbf23287f390dba13d7927ffa1586d3208e0e8d615d0c506f996"},
+    {file = "SQLAlchemy-1.3.24-cp36-cp36m-win_amd64.whl", hash = "sha256:f03bd97650d2e42710fbe4cf8a59fae657f191df851fc9fc683ecef10746a375"},
+    {file = "SQLAlchemy-1.3.24-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:a006d05d9aa052657ee3e4dc92544faae5fcbaafc6128217310945610d862d39"},
+    {file = "SQLAlchemy-1.3.24-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1e2f89d2e5e3c7a88e25a3b0e43626dba8db2aa700253023b82e630d12b37109"},
+    {file = "SQLAlchemy-1.3.24-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:0d5d862b1cfbec5028ce1ecac06a3b42bc7703eb80e4b53fceb2738724311443"},
+    {file = "SQLAlchemy-1.3.24-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:0172423a27fbcae3751ef016663b72e1a516777de324a76e30efa170dbd3dd2d"},
+    {file = "SQLAlchemy-1.3.24-cp37-cp37m-win32.whl", hash = "sha256:d37843fb8df90376e9e91336724d78a32b988d3d20ab6656da4eb8ee3a45b63c"},
+    {file = "SQLAlchemy-1.3.24-cp37-cp37m-win_amd64.whl", hash = "sha256:c10ff6112d119f82b1618b6dc28126798481b9355d8748b64b9b55051eb4f01b"},
+    {file = "SQLAlchemy-1.3.24-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:861e459b0e97673af6cc5e7f597035c2e3acdfb2608132665406cded25ba64c7"},
+    {file = "SQLAlchemy-1.3.24-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:5de2464c254380d8a6c20a2746614d5a436260be1507491442cf1088e59430d2"},
+    {file = "SQLAlchemy-1.3.24-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d375d8ccd3cebae8d90270f7aa8532fe05908f79e78ae489068f3b4eee5994e8"},
+    {file = "SQLAlchemy-1.3.24-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:014ea143572fee1c18322b7908140ad23b3994036ef4c0d630110faf942652f8"},
+    {file = "SQLAlchemy-1.3.24-cp38-cp38-win32.whl", hash = "sha256:6607ae6cd3a07f8a4c3198ffbf256c261661965742e2b5265a77cd5c679c9bba"},
+    {file = "SQLAlchemy-1.3.24-cp38-cp38-win_amd64.whl", hash = "sha256:fcb251305fa24a490b6a9ee2180e5f8252915fb778d3dafc70f9cc3f863827b9"},
+    {file = "SQLAlchemy-1.3.24-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:01aa5f803db724447c1d423ed583e42bf5264c597fd55e4add4301f163b0be48"},
+    {file = "SQLAlchemy-1.3.24-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4d0e3515ef98aa4f0dc289ff2eebb0ece6260bbf37c2ea2022aad63797eacf60"},
+    {file = "SQLAlchemy-1.3.24-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:bce28277f308db43a6b4965734366f533b3ff009571ec7ffa583cb77539b84d6"},
+    {file = "SQLAlchemy-1.3.24-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:8110e6c414d3efc574543109ee618fe2c1f96fa31833a1ff36cc34e968c4f233"},
+    {file = "SQLAlchemy-1.3.24-cp39-cp39-win32.whl", hash = "sha256:ee5f5188edb20a29c1cc4a039b074fdc5575337c9a68f3063449ab47757bb064"},
+    {file = "SQLAlchemy-1.3.24-cp39-cp39-win_amd64.whl", hash = "sha256:09083c2487ca3c0865dc588e07aeaa25416da3d95f7482c07e92f47e080aa17b"},
+    {file = "SQLAlchemy-1.3.24.tar.gz", hash = "sha256:ebbb777cbf9312359b897bf81ba00dae0f5cb69fba2a18265dcc18a6f5ef7519"},
 ]
 starlette = [
     {file = "starlette-0.13.6-py3-none-any.whl", hash = "sha256:bd2ffe5e37fb75d014728511f8e68ebf2c80b0fa3d04ca1479f4dc752ae31ac9"},
@@ -1255,8 +1318,8 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.3-py2.py3-none-any.whl", hash = "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80"},
-    {file = "urllib3-1.26.3.tar.gz", hash = "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"},
+    {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},
+    {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
 ]
 uvicorn = [
     {file = "uvicorn-0.11.8-py3-none-any.whl", hash = "sha256:4b70ddb4c1946e39db9f3082d53e323dfd50634b95fd83625d778729ef1730ef"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ uvicorn = "^0.11.8"
 # to <3.4 to fix Dockerfile build.
 # https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#34---2021-02-07
 # https://cryptography.io/en/latest/installation.html#alpine
-# TODO update base image to update cryptography
 cryptography = "<3.4"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ include = [
 python = "^3.7"
 alembic = "^1.4.2"
 authutils = "^5.0.4"
+boto3 = "^1.14"
 cdislogging = "^=1.0.0"
 fastapi = "^0.61.0"
 gen3authz = "^1.0.0"
@@ -29,6 +30,7 @@ uvicorn = "^0.11.8"
 # to <3.4 to fix Dockerfile build.
 # https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#34---2021-02-07
 # https://cryptography.io/en/latest/installation.html#alpine
+# TODO update base image to update cryptography
 cryptography = "<3.4"
 
 [tool.poetry.dev-dependencies]

--- a/src/audit/app.py
+++ b/src/audit/app.py
@@ -29,6 +29,7 @@ except:
     config.load(config_path=DEFAULT_CFG_PATH)
 
 from .models import db
+from .pull_from_queue import pull_from_queue_loop
 
 
 def load_modules(app: FastAPI = None) -> None:
@@ -69,6 +70,12 @@ def app_init() -> FastAPI:
 
     db.init_app(app)
     load_modules(app)
+
+    @app.on_event("startup")
+    async def startup_event():
+        if config["PULL_FROM_QUEUE"]:
+            loop = asyncio.get_running_loop()
+            loop.create_task(pull_from_queue_loop())
 
     @app.on_event("shutdown")
     async def shutdown_event():

--- a/src/audit/config-default.yaml
+++ b/src/audit/config-default.yaml
@@ -16,15 +16,16 @@ ARBORIST_URL:
 # logs can only be created by hitting the API's log creation endpoint.
 PULL_FROM_QUEUE: true
 # `QUEUE_CONFIG.type` is one of: [aws_sqs].
-# - if type == aws_sqs: logs are pulled from an SQS and fields `sqs_url` and
-# `region` are required. Fields `aws_access_key_id` and
+# - if type == aws_sqs: logs are pulled from an SQS and `aws_sqs_config`
+# fields `sqs_url` and `region` are required. Fields `aws_access_key_id` and
 # `aws_secret_access_key` are optional.
 QUEUE_CONFIG:
   type: aws_sqs
-  sqs_url:
-  region:
-  aws_access_key_id:
-  aws_secret_access_key:
+  aws_sqs_config:
+    sqs_url:
+    region:
+    aws_access_key_id:
+    aws_secret_access_key:
 # how often to check the queue for new audit logs after
 # seeing an empty queue
 PULL_FREQUENCY_SECONDS: 300  # default: 5 min

--- a/src/audit/config-default.yaml
+++ b/src/audit/config-default.yaml
@@ -12,8 +12,14 @@ DOCS_URL_PREFIX: /audit
 # defaults to "http://arborist-service/"
 ARBORIST_URL:
 
+# If `PULL_FROM_QUEUE` is true, `QUEUE_CONFIG` is required.
+# `QUEUE_CONFIG.type` is one of: [aws_sqs].
+# - if type == api: logs are created by hitting the log creation endpoint.
+# - if type == aws_sqs: logs are pulled from an SQS and fields `sqs_url` and
+# `region` are required. Fields `aws_access_key_id` and
+# `aws_secret_access_key` are optional.
 PULL_FROM_QUEUE: true
-QUEUE_CONFIG:  # TODO comment
+QUEUE_CONFIG:
   type: aws_sqs
   sqs_url:
   region:

--- a/src/audit/config-default.yaml
+++ b/src/audit/config-default.yaml
@@ -27,7 +27,7 @@ QUEUE_CONFIG:
   aws_secret_access_key:
 # how often to check the queue for new audit logs after
 # seeing an empty queue
-PULL_FREQUENCY_SECONDS: 1  # TODO less frequent
+PULL_FREQUENCY_SECONDS: 300  # default: 5 min
 
 ####################
 # DATABASE         #

--- a/src/audit/config-default.yaml
+++ b/src/audit/config-default.yaml
@@ -12,6 +12,17 @@ DOCS_URL_PREFIX: /audit
 # defaults to "http://arborist-service/"
 ARBORIST_URL:
 
+PULL_FROM_QUEUE: true
+QUEUE_CONFIG:  # TODO comment
+  type: aws_sqs
+  sqs_url:
+  region:
+  aws_access_key_id:
+  aws_secret_access_key:
+# how often to check the queue for new audit logs after
+# seeing an empty queue
+PULL_FREQUENCY_SECONDS: 1  # TODO less frequent
+
 ####################
 # DATABASE         #
 ####################

--- a/src/audit/config-default.yaml
+++ b/src/audit/config-default.yaml
@@ -14,7 +14,6 @@ ARBORIST_URL:
 
 # If `PULL_FROM_QUEUE` is true, `QUEUE_CONFIG` is required.
 # `QUEUE_CONFIG.type` is one of: [aws_sqs].
-# - if type == api: logs are created by hitting the log creation endpoint.
 # - if type == aws_sqs: logs are pulled from an SQS and fields `sqs_url` and
 # `region` are required. Fields `aws_access_key_id` and
 # `aws_secret_access_key` are optional.

--- a/src/audit/config-default.yaml
+++ b/src/audit/config-default.yaml
@@ -12,12 +12,13 @@ DOCS_URL_PREFIX: /audit
 # defaults to "http://arborist-service/"
 ARBORIST_URL:
 
-# If `PULL_FROM_QUEUE` is true, `QUEUE_CONFIG` is required.
+# If `PULL_FROM_QUEUE` is true, `QUEUE_CONFIG` is required. Otherwise,
+# logs can only be created by hitting the API's log creation endpoint.
+PULL_FROM_QUEUE: true
 # `QUEUE_CONFIG.type` is one of: [aws_sqs].
 # - if type == aws_sqs: logs are pulled from an SQS and fields `sqs_url` and
 # `region` are required. Fields `aws_access_key_id` and
 # `aws_secret_access_key` are optional.
-PULL_FROM_QUEUE: true
 QUEUE_CONFIG:
   type: aws_sqs
   sqs_url:

--- a/src/audit/config.py
+++ b/src/audit/config.py
@@ -29,7 +29,20 @@ class AuditServiceConfig(Config):
         """
         Perform a series of sanity checks on a loaded config.
         """
-        pass
+        if self["PULL_FROM_QUEUE"]:
+            assert "QUEUE_CONFIG" in self, "Config is missing 'QUEUE_CONFIG'"
+            queue_type = self["QUEUE_CONFIG"].get("type")
+            if queue_type == "aws_sqs":
+                assert (
+                    "sqs_url" in self["QUEUE_CONFIG"]
+                ), "Config is missing 'QUEUE_CONFIG.sqs_url'"
+                assert (
+                    "region" in self["QUEUE_CONFIG"]
+                ), "Config is missing 'QUEUE_CONFIG.region'"
+            else:
+                raise Exception(
+                    f"Config 'QUEUE_CONFIG.type': unknown queue type '{queue_type}'"
+                )
 
 
 config = AuditServiceConfig(DEFAULT_CFG_PATH)

--- a/src/audit/config.py
+++ b/src/audit/config.py
@@ -25,7 +25,7 @@ class AuditServiceConfig(Config):
             ),
         )
 
-    def validate(self) -> None:
+    def validate(self, logger) -> None:
         """
         Perform a series of sanity checks on a loaded config.
         """
@@ -33,12 +33,11 @@ class AuditServiceConfig(Config):
             assert "QUEUE_CONFIG" in self, "Config is missing 'QUEUE_CONFIG'"
             queue_type = self["QUEUE_CONFIG"].get("type")
             if queue_type == "aws_sqs":
-                assert (
-                    "sqs_url" in self["QUEUE_CONFIG"]
-                ), "Config is missing 'QUEUE_CONFIG.sqs_url'"
-                assert (
-                    "region" in self["QUEUE_CONFIG"]
-                ), "Config is missing 'QUEUE_CONFIG.region'"
+                for key in ["sqs_url", "region"]:
+                    if not self["QUEUE_CONFIG"].get(key):
+                        logger.warning(
+                            f"'PULL_FROM_QUEUE' is enabled with 'type' == 'aws_sqs', but config is missing 'QUEUE_CONFIG.{key}'"
+                        )
             else:
                 raise Exception(
                     f"Config 'QUEUE_CONFIG.type': unknown queue type '{queue_type}'"

--- a/src/audit/config.py
+++ b/src/audit/config.py
@@ -33,10 +33,14 @@ class AuditServiceConfig(Config):
             assert "QUEUE_CONFIG" in self, "Config is missing 'QUEUE_CONFIG'"
             queue_type = self["QUEUE_CONFIG"].get("type")
             if queue_type == "aws_sqs":
+                aws_sqs_config = self["QUEUE_CONFIG"].get("aws_sqs_config")
+                assert (
+                    aws_sqs_config
+                ), f"'PULL_FROM_QUEUE' is enabled with 'type' == 'aws_sqs', but config is missing 'QUEUE_CONFIG.aws_sqs_config'"
                 for key in ["sqs_url", "region"]:
-                    if not self["QUEUE_CONFIG"].get(key):
+                    if not aws_sqs_config.get(key):
                         logger.warning(
-                            f"'PULL_FROM_QUEUE' is enabled with 'type' == 'aws_sqs', but config is missing 'QUEUE_CONFIG.{key}'"
+                            f"'PULL_FROM_QUEUE' is enabled with 'type' == 'aws_sqs', but config is missing 'QUEUE_CONFIG.aws_sqs_config.{key}'"
                         )
             else:
                 raise Exception(

--- a/src/audit/models.py
+++ b/src/audit/models.py
@@ -44,17 +44,23 @@ class CreateLogInput(BaseModel):
 
 
 class PresignedUrl(AuditLog):
+    """
+    `resource_paths` can be null if the user requested a file that
+    doesn't exist.
+    `protocol` can be null in the same case or if action=="upload"
+    """
+
     __tablename__ = "presigned_url"
 
     guid = Column(String, nullable=False)
-    resource_paths = Column(ARRAY(String), nullable=False)
+    resource_paths = Column(ARRAY(String), nullable=True)
     action = Column(String, nullable=False)
-    protocol = Column(String, nullable=True)  # can be null if action=="upload"
+    protocol = Column(String, nullable=True)
 
 
 class CreatePresignedUrlLogInput(CreateLogInput):
     guid: str
-    resource_paths: list
+    resource_paths: list = None
     action: str
     protocol: str = None
 

--- a/src/audit/models.py
+++ b/src/audit/models.py
@@ -1,9 +1,8 @@
-from datetime import datetime
 from gino.ext.starlette import Gino
 from pydantic import BaseModel
 import sqlalchemy
-from sqlalchemy import Column, DateTime, Integer, String, UniqueConstraint
-from sqlalchemy.dialects.postgresql import ARRAY, TIMESTAMP
+from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy.dialects.postgresql import ARRAY
 
 from .config import config
 

--- a/src/audit/pull_from_queue.py
+++ b/src/audit/pull_from_queue.py
@@ -42,9 +42,6 @@ async def pull_from_queue_loop():
             response = sqs.receive_message(
                 QueueUrl=config["QUEUE_CONFIG"]["sqs_url"],
                 MaxNumberOfMessages=10,  # 10 is the max
-                # TODO check below fields
-                # VisibilityTimeout=0,
-                # WaitTimeSeconds=0
             )
             messages = response.get("Messages", [])
         except Exception as e:

--- a/src/audit/pull_from_queue.py
+++ b/src/audit/pull_from_queue.py
@@ -32,7 +32,7 @@ async def pull_from_queue(sqs):
     try:
         response = sqs.receive_message(
             QueueUrl=config["QUEUE_CONFIG"]["sqs_url"],
-            MaxNumberOfMessages=10,  # 10 is the max
+            MaxNumberOfMessages=10,  # 10 is the max allowed by AWS
         )
         messages = response.get("Messages", [])
     except Exception as e:

--- a/src/audit/pull_from_queue.py
+++ b/src/audit/pull_from_queue.py
@@ -1,0 +1,69 @@
+import asyncio
+import boto3
+import json
+import traceback
+
+from .config import config
+from .models import CATEGORY_TO_MODEL_CLASS
+from .routes.maintain import insert_row, validate_presigned_url_log, validate_login_log
+
+
+async def process_log(data):
+    # check log category
+    category = data.pop("category")
+    assert category and category in CATEGORY_TO_MODEL_CLASS, "TODO error msg"
+
+    # validate log
+    if category == "presigned_url":
+        validate_presigned_url_log(data)
+    elif category == "login":
+        validate_login_log(data)
+
+    # insert log in DB
+    await insert_row(category, data)
+
+
+async def pull_from_queue_loop():
+    # TODO validate QUEUE_CONFIG
+    sqs = boto3.client(
+        "sqs",
+        region_name=config["QUEUE_CONFIG"]["region"],
+        aws_access_key_id=config["QUEUE_CONFIG"]["aws_access_key_id"],
+        aws_secret_access_key=config["QUEUE_CONFIG"]["aws_secret_access_key"],
+    )
+    while True:
+        failed = False
+        messages = []
+        try:
+            response = sqs.receive_message(
+                QueueUrl=config["QUEUE_CONFIG"]["sqs_url"],
+                MaxNumberOfMessages=10,  # 10 is the max
+                # TODO check below fields
+                # VisibilityTimeout=0,
+                # WaitTimeSeconds=0
+            )
+            messages = response.get("Messages", [])
+        except Exception as e:
+            failed = True
+            print(f"ERROR: {e}")  # TODO use logger instead of print
+
+        for message in messages:
+            data = json.loads(message["Body"])
+            receipt_handle = message['ReceiptHandle']
+            try:
+                await process_log(data)
+            except Exception as e:
+                failed = True
+                print(f"ERROR: {e}")  # TODO use logger instead of print
+                traceback.print_exc()
+            else:
+                # delete message from queue once successfully processed
+                sqs.delete_message(
+                    QueueUrl=config["QUEUE_CONFIG"]["sqs_url"],
+                    ReceiptHandle=receipt_handle
+                )
+
+        if not messages or failed:  # queue is empty: sleep
+            print("sleeping...")
+            await asyncio.sleep(3)  # TODO remove
+            # await asyncio.sleep(config["PULL_FREQUENCY_SECONDS"])

--- a/src/audit/pull_from_queue.py
+++ b/src/audit/pull_from_queue.py
@@ -31,7 +31,7 @@ async def pull_from_queue(sqs):
     messages = []
     try:
         response = sqs.receive_message(
-            QueueUrl=config["QUEUE_CONFIG"]["sqs_url"],
+            QueueUrl=config["QUEUE_CONFIG"]["aws_sqs_config"]["sqs_url"],
             MaxNumberOfMessages=10,  # 10 is the max allowed by AWS
         )
         messages = response.get("Messages", [])
@@ -53,7 +53,7 @@ async def pull_from_queue(sqs):
             # delete message from queue once successfully processed
             try:
                 sqs.delete_message(
-                    QueueUrl=config["QUEUE_CONFIG"]["sqs_url"],
+                    QueueUrl=config["QUEUE_CONFIG"]["aws_sqs_config"]["sqs_url"],
                     ReceiptHandle=receipt_handle,
                 )
             except Exception as e:
@@ -72,11 +72,12 @@ async def pull_from_queue_loop():
     AWS SQS right now.
     """
     logger.info("Starting to pull from queue...")
+    aws_sqs_config = config["QUEUE_CONFIG"]["aws_sqs_config"]
     sqs = boto3.client(
         "sqs",
-        region_name=config["QUEUE_CONFIG"]["region"],
-        aws_access_key_id=config["QUEUE_CONFIG"].get("aws_access_key_id"),
-        aws_secret_access_key=config["QUEUE_CONFIG"].get("aws_secret_access_key"),
+        region_name=aws_sqs_config["region"],
+        aws_access_key_id=aws_sqs_config.get("aws_access_key_id"),
+        aws_secret_access_key=aws_sqs_config.get("aws_secret_access_key"),
     )
     sleep_time = config["PULL_FREQUENCY_SECONDS"]
     while True:

--- a/src/audit/pull_from_queue.py
+++ b/src/audit/pull_from_queue.py
@@ -3,6 +3,7 @@ import boto3
 import json
 import traceback
 
+from . import logger
 from .config import config
 from .models import CATEGORY_TO_MODEL_CLASS
 from .routes.maintain import insert_row, validate_presigned_url_log, validate_login_log
@@ -11,7 +12,9 @@ from .routes.maintain import insert_row, validate_presigned_url_log, validate_lo
 async def process_log(data):
     # check log category
     category = data.pop("category")
-    assert category and category in CATEGORY_TO_MODEL_CLASS, "TODO error msg"
+    assert (
+        category and category in CATEGORY_TO_MODEL_CLASS
+    ), f"Unknown log category {category}"
 
     # validate log
     if category == "presigned_url":
@@ -24,13 +27,14 @@ async def process_log(data):
 
 
 async def pull_from_queue_loop():
-    # TODO validate QUEUE_CONFIG
+    logger.info("Starting to pull from queue...")
     sqs = boto3.client(
         "sqs",
         region_name=config["QUEUE_CONFIG"]["region"],
-        aws_access_key_id=config["QUEUE_CONFIG"]["aws_access_key_id"],
-        aws_secret_access_key=config["QUEUE_CONFIG"]["aws_secret_access_key"],
+        aws_access_key_id=config["QUEUE_CONFIG"].get("aws_access_key_id"),
+        aws_secret_access_key=config["QUEUE_CONFIG"].get("aws_secret_access_key"),
     )
+    sleep_time = config["PULL_FREQUENCY_SECONDS"]
     while True:
         failed = False
         messages = []
@@ -45,25 +49,30 @@ async def pull_from_queue_loop():
             messages = response.get("Messages", [])
         except Exception as e:
             failed = True
-            print(f"ERROR: {e}")  # TODO use logger instead of print
+            logger.error(f"Error pulling from queue: {e}")
+            traceback.print_exc()
 
         for message in messages:
             data = json.loads(message["Body"])
-            receipt_handle = message['ReceiptHandle']
+            receipt_handle = message["ReceiptHandle"]
             try:
                 await process_log(data)
             except Exception as e:
                 failed = True
-                print(f"ERROR: {e}")  # TODO use logger instead of print
+                logger.error(f"Error processing audit log: {e}")
                 traceback.print_exc()
             else:
                 # delete message from queue once successfully processed
-                sqs.delete_message(
-                    QueueUrl=config["QUEUE_CONFIG"]["sqs_url"],
-                    ReceiptHandle=receipt_handle
-                )
+                try:
+                    sqs.delete_message(
+                        QueueUrl=config["QUEUE_CONFIG"]["sqs_url"],
+                        ReceiptHandle=receipt_handle,
+                    )
+                except Exception as e:
+                    failed = True
+                    logger.error(f"Error deleting message from queue: {e}")
+                    traceback.print_exc()
 
         if not messages or failed:  # queue is empty: sleep
-            print("sleeping...")
-            await asyncio.sleep(3)  # TODO remove
-            # await asyncio.sleep(config["PULL_FREQUENCY_SECONDS"])
+            logger.info(f"Sleeping for {sleep_time} seconds...")
+            await asyncio.sleep(sleep_time)

--- a/src/audit/routes/maintain.py
+++ b/src/audit/routes/maintain.py
@@ -1,26 +1,14 @@
-import uuid
-
-from asyncpg.exceptions import UniqueViolationError
 from datetime import datetime
-from enum import Enum
-from fastapi import APIRouter, BackgroundTasks, Body, Depends, FastAPI, HTTPException
-from gino.exceptions import NoSuchRowError
-from starlette.requests import Request
+from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI, HTTPException
 from starlette.status import (
-    HTTP_200_OK,
     HTTP_201_CREATED,
     HTTP_400_BAD_REQUEST,
-    HTTP_403_FORBIDDEN,
-    HTTP_409_CONFLICT,
-    HTTP_500_INTERNAL_SERVER_ERROR,
 )
 
 from .. import logger
 from ..auth import Auth
-from ..config import config
 from ..models import (
     CATEGORY_TO_MODEL_CLASS,
-    db,
     CreateLoginLogInput,
     CreatePresignedUrlLogInput,
 )
@@ -50,7 +38,7 @@ async def insert_row(category, data):
     is raised, we just catch and ignore it.
 
     TODO Once a newer version of GINO is released, upgrade and catch
-    `NoSuchRowError` instead of `AttributeError`.
+    `gino.exceptions.NoSuchRowError` instead of `AttributeError`.
     """
     try:
         await CATEGORY_TO_MODEL_CLASS[category].create(**data)

--- a/src/audit/routes/maintain.py
+++ b/src/audit/routes/maintain.py
@@ -71,8 +71,13 @@ def handle_timestamp(data):
         return
     if data["timestamp"]:
         # we take a timestamp as input, but store a datetime in the database
-        # TODO timestamp to datetime error handling
-        data["timestamp"] = datetime.fromtimestamp(data["timestamp"])
+        try:
+            data["timestamp"] = datetime.fromtimestamp(data["timestamp"])
+        except Exception as e:
+            raise HTTPException(
+                HTTP_400_BAD_REQUEST,
+                f"Invalid timestamp '{data['timestamp']}'",
+            )
     else:
         # when hitting the API endpoint, the "timestamp" key always exists
         # because it's defined in `CreateLogInput`. It is automatically added

--- a/src/audit/routes/maintain.py
+++ b/src/audit/routes/maintain.py
@@ -102,7 +102,8 @@ def validate_presigned_url_log(data):
     logger.debug(f"Creating `presigned_url` audit log. Received body: {data}")
 
     allowed_actions = ["download", "upload"]
-    if data["action"] not in allowed_actions:
+    # `action` is a required field", but that's checked during the DB insert
+    if "action" in data and data["action"] not in allowed_actions:
         raise HTTPException(
             HTTP_400_BAD_REQUEST,
             f"Action '{data['action']}' is not allowed ({allowed_actions})",

--- a/src/audit/routes/query.py
+++ b/src/audit/routes/query.py
@@ -1,12 +1,10 @@
 from collections import defaultdict
 from datetime import datetime
-from fastapi import APIRouter, Body, Depends, FastAPI, HTTPException, Query
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query
 from starlette.requests import Request
 from starlette.status import (
     HTTP_200_OK,
     HTTP_400_BAD_REQUEST,
-    HTTP_404_NOT_FOUND,
 )
 import time
 
@@ -19,7 +17,7 @@ from ..models import CATEGORY_TO_MODEL_CLASS, db
 router = APIRouter()
 
 
-@router.get("/log/{category}")
+@router.get("/log/{category}", status_code=HTTP_200_OK)
 async def query_logs(
     request: Request,
     category: str,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 from alembic.config import main as alembic_main
 import copy
-import importlib
 import os
 import pytest
 import requests

--- a/tests/test-audit-service-config.yaml
+++ b/tests/test-audit-service-config.yaml
@@ -1,6 +1,7 @@
 DEBUG: true
 TEST_KEEP_DB: false
 DOCS_URL_PREFIX: /
+PULL_FROM_QUEUE: false  # TODO tests for queue
 
 # These are required for automated testing (see .github/workflows/ci.yaml)
 DB_DRIVER: postgresql

--- a/tests/test-audit-service-config.yaml
+++ b/tests/test-audit-service-config.yaml
@@ -1,7 +1,6 @@
 DEBUG: true
 TEST_KEEP_DB: false
 DOCS_URL_PREFIX: /
-PULL_FROM_QUEUE: false  # TODO tests for queue
 
 # These are required for automated testing (see .github/workflows/ci.yaml)
 DB_DRIVER: postgresql

--- a/tests/test_maintain.py
+++ b/tests/test_maintain.py
@@ -1,6 +1,4 @@
 from datetime import datetime
-import pytest
-from unittest.mock import patch
 import time
 
 
@@ -36,6 +34,24 @@ def test_create_presigned_url_log_with_timestamp(client):
     response_timestamp = response_data.pop("timestamp").replace("T", " ")
     assert response_timestamp == request_timestamp
     assert response_data == request_data
+
+
+def test_create_presigned_url_log_with_bad_timestamp(client):
+    # create a log with a timestamp
+    guid = "dg.hello/abc"
+    request_data = {
+        "request_url": f"/request_data/download/{guid}",
+        "status_code": 200,
+        "timestamp": 999999999999999,
+        "username": "audit-service_user",
+        "sub": 10,
+        "guid": guid,
+        "resource_paths": ["/my/resource/path1", "/path2"],
+        "action": "download",
+        "protocol": "s3",
+    }
+    res = client.post("/log/presigned_url", json=request_data)
+    assert res.status_code == 400, res.text
 
 
 def test_create_presigned_url_log_without_timestamp(client):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,7 +1,4 @@
 from datetime import datetime
-import pytest
-from random import randint
-import time
 
 from audit.config import config
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -148,7 +148,9 @@ async def test_pull_from_queue_success(monkeypatch):
     Test that `pull_from_queue` properly processes messages in the queue.
     """
     queue = TestQueue()
-    monkeypatch.setitem(config, "QUEUE_CONFIG", {"sqs_url": "some_queue_url"})
+    monkeypatch.setitem(
+        config, "QUEUE_CONFIG", {"aws_sqs_config": {"sqs_url": "some_queue_url"}}
+    )
     monkeypatch.setitem(config, "PULL_FREQUENCY_SECONDS", 0)
 
     should_sleep = await pull_from_queue(queue)
@@ -176,7 +178,9 @@ async def test_pull_from_queue_failure(monkeypatch):
     for messages in [[bad_message], []]:
         print(f"Messages: {messages}")
         queue = TestQueue(messages=messages)
-        monkeypatch.setitem(config, "QUEUE_CONFIG", {"sqs_url": "some_queue_url"})
+        monkeypatch.setitem(
+            config, "QUEUE_CONFIG", {"aws_sqs_config": {"sqs_url": "some_queue_url"}}
+        )
         monkeypatch.setitem(config, "PULL_FREQUENCY_SECONDS", 0)
 
         should_sleep = await pull_from_queue(queue)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,195 @@
+import json
+import time
+import pytest
+
+from audit.config import config
+from audit.models import CATEGORY_TO_MODEL_CLASS, db
+from audit.pull_from_queue import process_log, pull_from_queue
+
+
+@pytest.mark.asyncio
+async def test_process_log_success():
+    """
+    Test that `process_log` properly inserts audit logs into the DB.
+
+    We can't query logs by using the `client` fixture because of this issue
+    https://github.com/encode/starlette/issues/440, so querying the DB directly
+    instead.
+    """
+    # create a log
+    guid = "dg.hello/abc"
+    category = "presigned_url"
+    message_data = {
+        "category": category,
+        "request_url": f"/request_data/download/{guid}",
+        "status_code": 200,
+        "timestamp": int(time.time()),
+        "username": "audit-service_user",
+        "sub": 10,
+        "guid": guid,
+        "resource_paths": ["/my/resource/path1", "/path2"],
+        "action": "download",
+        "protocol": "s3",
+    }
+    await process_log(message_data)
+
+    data = await db.all(db.text(f"select * from {category}"))
+    assert len(data) == 1, f"1 row should have been inserted in table '{category}'"
+    assert data[0] == (
+        message_data["request_url"],
+        message_data["status_code"],
+        message_data["timestamp"],
+        message_data["username"],
+        message_data["sub"],
+        guid,
+        message_data["resource_paths"],
+        message_data["action"],
+        message_data["protocol"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_log_failure():
+    """
+    Test that `process_log` properly rejects bad audit logs.
+
+    We can't query logs by using the `client` fixture because of this issue
+    https://github.com/encode/starlette/issues/440, so querying the DB directly
+    instead.
+    """
+    # attempt to create a log with a bad category
+    guid = "dg.hello/abc"
+    category = "this_does_not_exist"
+    message_data = {
+        "category": category,
+        "request_url": f"/request_data/download/{guid}",
+        "status_code": 200,
+        "timestamp": int(time.time()),
+        "username": "audit-service_user",
+        "sub": 10,
+        "guid": guid,
+        "resource_paths": ["/my/resource/path1", "/path2"],
+        "action": "download",
+        "protocol": "s3",
+    }
+    with pytest.raises(AssertionError, match=f"Unknown log category {category}"):
+        await process_log(message_data)
+
+    for category in CATEGORY_TO_MODEL_CLASS:
+        data = await db.all(db.text(f"select * from {category}"))
+        assert (
+            len(data) == 0
+        ), f"Nothing should have been inserted in table '{category}'"
+
+    # attempt to create a log with missing fields
+    guid = "dg.hello/abc"
+    category = "presigned_url"
+    message_data = {
+        "category": category,
+        "request_url": f"/request_data/download/{guid}",
+        "status_code": 200,
+        "username": "audit-service_user",
+        "action": "download",
+    }
+    with pytest.raises(Exception, match="null value in column"):
+        await process_log(message_data)
+
+    # make sure `process_log` did not insert any rows
+    for category in CATEGORY_TO_MODEL_CLASS:
+        data = await db.all(db.text(f"select * from {category}"))
+        assert (
+            len(data) == 0
+        ), f"Nothing should have been inserted in table '{category}'"
+
+
+class TestQueue:
+    """
+    This class mocks the boto3 SQS client
+    """
+
+    def __init__(self, messages=None) -> None:
+        guid = "dg.hello/abc"
+        if messages is None:
+            self.messages = [
+                {
+                    "category": "presigned_url",
+                    "request_url": f"/request_data/download/{guid}",
+                    "status_code": 200,
+                    "timestamp": int(time.time()),
+                    "username": "audit-service_user",
+                    "sub": 10,
+                    "guid": guid,
+                    "resource_paths": ["/my/resource/path1", "/path2"],
+                    "action": "download",
+                    "protocol": "s3",
+                }
+            ]
+        else:
+            self.messages = messages
+
+    def receive_message(self, QueueUrl, MaxNumberOfMessages):
+        n_messages = min(MaxNumberOfMessages, len(self.messages))
+        messages = [
+            {
+                "Body": json.dumps(message),
+                "ReceiptHandle": "123",
+            }
+            for message in self.messages[:n_messages]
+        ]
+        return {"Messages": messages}
+
+    def delete_message(self, QueueUrl, ReceiptHandle):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_pull_from_queue_success(monkeypatch):
+    """
+    Test that `pull_from_queue` properly processes messages in the queue.
+    """
+    queue = TestQueue()
+    monkeypatch.setitem(config, "QUEUE_CONFIG", {"sqs_url": "some_queue_url"})
+    monkeypatch.setitem(config, "PULL_FREQUENCY_SECONDS", 0)
+
+    should_sleep = await pull_from_queue(queue)
+    # `should_sleep` is True if the queue contains no messages (not the
+    # case here) or if we failed to process a message (should not happen)
+    assert not should_sleep, "Failed to process audit logs"
+
+    # make sure `process_log` inserted a row
+    data = await db.all(db.text(f"select * from presigned_url"))
+    assert len(data) == 1, f"1 row should have been inserted in table 'presigned_url'"
+
+
+@pytest.mark.asyncio
+async def test_pull_from_queue_failure(monkeypatch):
+    """
+    Test that `pull_from_queue` fails when it should and sleeps when it should.
+    """
+    bad_message = {
+        "category": "presigned_url",
+        "request_url": f"/request_data/download/guid",
+        "status_code": 200,
+        "username": "audit-service_user",
+        "action": "download",
+    }
+    for messages in [[bad_message], []]:
+        print(f"Messages: {messages}")
+        queue = TestQueue(messages=messages)
+        monkeypatch.setitem(config, "QUEUE_CONFIG", {"sqs_url": "some_queue_url"})
+        monkeypatch.setitem(config, "PULL_FREQUENCY_SECONDS", 0)
+
+        should_sleep = await pull_from_queue(queue)
+        # `should_sleep` is True if the queue contains no messages (not the
+        # case here) or if we failed to process a message (should happen)
+        if not messages:
+            err_msg = "Should not have processed any audit logs"
+        else:
+            err_msg = "Should have failed to process audit logs"
+        assert should_sleep, err_msg
+
+        # make sure `process_log` did not insert any rows
+        data = await db.all(db.text(f"select * from presigned_url"))
+        assert (
+            len(data) == 0
+        ), f"Nothing should have been inserted in table 'presigned_url'"


### PR DESCRIPTION
Jira Ticket: [PXP-7805](https://ctds-planx.atlassian.net/browse/PXP-7805)

goes with https://github.com/uc-cdis/fence/pull/923 and https://github.com/uc-cdis/cloud-automation/pull/1603

### New Features
- The audit service can be configured to fetch audit logs from an AWS SQS

### Improvements
- Return an error if an invalid timestamp is provided to the log creation endpoint
- Presigned URL logs can now have an empty "resource_paths" field

### Dependency updates
- Add dependency to boto3 version ^1.14

### Deployment changes
- **If a previous version of the audit service has already been deployed**, run `kubectl delete secret audit-g3auto` and `gen3 kube-setup-audit-service` to configure the audit SQS and update the configuration file. OR to disable pulling from a queue, update the configuration file manually to disable "PULL_FROM_QUEUE"
