### PR TITLE
PXP-8374 Allow empty 'sub' in presigned_url log creation

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -33,7 +33,6 @@ components:
       - request_url
       - status_code
       - username
-      - sub
       - idp
       title: CreateLoginLogInput
       type: object
@@ -71,7 +70,6 @@ components:
       - request_url
       - status_code
       - username
-      - sub
       - guid
       - action
       title: CreatePresignedUrlLogInput

--- a/src/audit/models.py
+++ b/src/audit/models.py
@@ -37,7 +37,7 @@ class CreateLogInput(BaseModel):
     # int timestamps as input
     timestamp: int = None
     username: str
-    sub: int
+    sub: int = None
 
 
 # child audit log classes

--- a/src/audit/routes/query.py
+++ b/src/audit/routes/query.py
@@ -89,8 +89,6 @@ async def query_logs(
 
         Returns: 2 (see previous example returning 2 rows)
     """
-    logger.debug(f"Querying category {category}")
-
     if category not in CATEGORY_TO_MODEL_CLASS:
         raise HTTPException(
             HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
Jira Ticket: [PXP-8374](https://ctds-planx.atlassian.net/browse/PXP-8374)

'sub' was nullable in the DB but the parameter was required

### Bug Fixes
- Presigned URL field "sub" can be None
