### PR TITLE
PXP-8310 Use SQS messages 'SentTimestamp'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 #!groovy
 
-// TODO: uncomment once we have integration tests for this service
-// @Library('cdis-jenkins-lib@master') _
+@Library('cdis-jenkins-lib@master') _
 
-// testPipeline {
-// }
+testPipeline {
+}

--- a/docs/explanation/creating_audit_logs.md
+++ b/docs/explanation/creating_audit_logs.md
@@ -11,3 +11,9 @@ However, it's difficult to monitor errors when using this endpoint.
 ## Pulling from a queue
 
 The audit service can also handle pulling audit logs from a queue, which allows for easier monitoring. This can be configured by turning on the `PULL_FROM_QUEUE` flag in the configuration file (enabled by default). Right now, only AWS SQS is integrated, but integrations for other types of queues can be added by adding code and extending the values accepted for the `QUEUE_CONFIG.type` field in the configuration file.
+
+## Timestamps
+
+In most cases, services should **not** provide a timestamp when creating audit logs. The timestamp is only accepted in log creation requests to allow populating the audit database with historical data, for example by parsing historical logs from before the Audit Service was deployed to a Data Commons.
+
+For other use cases, for consistency and to avoid mistakes, the timestamp should either be generated automatically by `audit-service` (when using the API's creation endpoint) or come from the message's `SentTimestamp` (when using AWS SQS).

--- a/docs/how-to/deployment.md
+++ b/docs/how-to/deployment.md
@@ -23,4 +23,4 @@ See the [Fence default configuration file](https://github.com/uc-cdis/fence/blob
 ## Notes
 
 1. When adding audit log creation in a service for the first time, the `audit-service` deployment file `network-ingress` annotation (see [here](https://github.com/uc-cdis/cloud-automation/blob/27770776d239bc609bbbd23607689cf62de1bc66/kube/services/audit-service/audit-service-deploy.yaml#L6)) must be updated to allow the service to talk to `audit-service`.
-2. In most cases, services should **not** provide a timestamp when creating audit logs. The timestamp is only accepted in log creation requests to allow populating the audit database with historical data, for example by parsing historical logs from before the Audit Service was deployed to a Data Commons.
+2. In most cases, services should **not** provide a timestamp when creating audit logs. See [Creating audit logs, Timestamps section](../explanation/creating_audit_logs.md#timestamps).

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -32,7 +32,7 @@ Filters can be added as query strings. Accepted filters include all fields for t
 
 If queries are time-boxed (depends on configuration variable `QUERY_TIMEBOX_MAX_DAYS`), (`stop` - `start`) must be lower than the configured maximum.
 
-We can populate the Audit Service database with historical data by parsing logs and making POST requests to create audit entries, because the POST endpoint accepts the timestamp as an optional parameter.
+We can populate the Audit Service database with historical data by parsing logs and making POST requests to create audit entries, because the log creation endpoint accepts the timestamp as an optional parameter.
 
 About retention: for now, there is no planned mechanism to delete old entries.
 

--- a/src/audit/pull_from_queue.py
+++ b/src/audit/pull_from_queue.py
@@ -9,12 +9,16 @@ from .models import CATEGORY_TO_MODEL_CLASS
 from .routes.maintain import insert_row, validate_presigned_url_log, validate_login_log
 
 
-async def process_log(data):
+async def process_log(data, timestamp):
     # check log category
     category = data.pop("category")
     assert (
         category and category in CATEGORY_TO_MODEL_CLASS
     ), f"Unknown log category {category}"
+
+    # if the timestamp was not provided, default to the message's SentTimestamp
+    if not data.get("timestamp"):
+        data["timestamp"] = timestamp
 
     # validate log
     if category == "presigned_url":
@@ -33,6 +37,7 @@ async def pull_from_queue(sqs):
         response = sqs.receive_message(
             QueueUrl=config["QUEUE_CONFIG"]["aws_sqs_config"]["sqs_url"],
             MaxNumberOfMessages=10,  # 10 is the max allowed by AWS
+            AttributeNames=["SentTimestamp"],
         )
         messages = response.get("Messages", [])
     except Exception as e:
@@ -43,8 +48,11 @@ async def pull_from_queue(sqs):
     for message in messages:
         data = json.loads(message["Body"])
         receipt_handle = message["ReceiptHandle"]
+        # when the message was sent to the queue
+        sent_timestamp = message["Attributes"]["SentTimestamp"]
+        timestamp = int(int(sent_timestamp) / 1000)  # ms to s
         try:
-            await process_log(data)
+            await process_log(data, timestamp)
         except Exception as e:
             failed = True
             logger.error(f"Error processing audit log: {e}")


### PR DESCRIPTION
Jira Ticket: [PXP-8310](https://ctds-planx.atlassian.net/browse/PXP-8310)

### Improvements
- Use SQS messages' 'SentTimestamp' instead of generating timestamps when processing audit logs
