### PR TITLE
Ignore cfg_help.py and docs/load_test.py in veracode scan

### DIFF
--- a/.secexclude
+++ b/.secexclude
@@ -54,3 +54,5 @@ docker-compose.yml
 ehthumbs.db
 test/*
 tests/*
+cfg_help.py
+docs/*


### PR DESCRIPTION
Ignore `cfg_help.py` and `docs/load_test.py` in veracode scan to avoid false positives in scripts that are not run in production