### PR TITLE
Fix querying timestamps

### DIFF
--- a/src/audit/routes/query.py
+++ b/src/audit/routes/query.py
@@ -218,6 +218,14 @@ def validate_and_normalize_times(start, stop):
 def add_filters(model, query, query_params, start_date=None, stop_date=None):
     def _type_cast(model, field, value):
         field_type = getattr(model, field).type.python_type
+        if field_type == datetime:
+            try:
+                return datetime.fromtimestamp(int(value))
+            except ValueError as e:
+                raise HTTPException(
+                    HTTP_400_BAD_REQUEST,
+                    f"Unable to convert value '{value}' to datetime for field '{field}': {e}",
+                )
         try:
             return field_type(value)
         except ValueError as e:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -188,6 +188,7 @@ def test_query_field_filter(client):
         headers={"Authorization": f"bearer {fake_jwt}"},
     )
     assert res.status_code == 200, res.text
+    response_data = res.json()["data"]
     assert len(response_data) == 1
     assert response_data[0] == log
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -180,6 +180,17 @@ def test_query_field_filter(client):
     assert len(response_data) == 1  # test log A2
     assert all(log["status_code"] == 401 for log in response_data)
 
+    # query logs for a timestamp (int=>datetime parameter)
+    log = response_data[0]
+    timestamp = timestamp_for_date(log["timestamp"].split("T")[0], format="%Y-%m-%d")
+    res = client.get(
+        f"/log/presigned_url?timestamp={timestamp}",
+        headers={"Authorization": f"bearer {fake_jwt}"},
+    )
+    assert res.status_code == 200, res.text
+    assert len(response_data) == 1
+    assert response_data[0] == log
+
     # query a value that is not the right type for the field
     res = client.get(
         "/log/presigned_url?status_code=string",


### PR DESCRIPTION
Fix error:
```
    def _type_cast(model, field, value):
        field_type = getattr(model, field).type.python_type
        try:
>           return field_type(value)
E           TypeError: an integer is required (got type str)
```

### Bug Fixes
- Fix querying timestamps
