### PR TITLE
Use pip to install poetry in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,11 +30,12 @@ jobs:
           ${{ runner.os }}-poetry-
     - name: Install dependencies
       run: |
-        curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
-        $HOME/.poetry/bin/poetry install
+        pip install poetry
+        poetry install -vv --no-root --no-interaction
+        poetry show -vv
     - name: Test with pytest
       run: |
-        $HOME/.poetry/bin/poetry run pytest tests/ -vv --cov=src --cov=migrations/versions --cov-report xml
+        poetry run pytest tests/ -vv --cov=src --cov=migrations/versions --cov-report xml
     - name: Submit coverage report
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install poetry
-        poetry install -vv --no-root --no-interaction
+        poetry install -vv --no-interaction
         poetry show -vv
     - name: Test with pytest
       run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,10 +25,11 @@ jobs:
           ${{ runner.os }}-poetry-
     - name: Install dependencies (allow "failures" and attempt to continue)
       run: |
-        curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python || true
-        $HOME/.poetry/bin/poetry install || true
+        pip install poetry
+        poetry install -vv --no-root --no-interaction
+        poetry show -vv
     - name: Build docs
-      run: AUDIT_SERVICE_CONFIG_PATH=src/audit/config-default.yaml $HOME/.poetry/bin/poetry run python run.py openapi
+      run: AUDIT_SERVICE_CONFIG_PATH=src/audit/config-default.yaml poetry run python run.py openapi
 
     - uses: stefanzweifel/git-auto-commit-action@v4.1.2
       with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,10 +23,10 @@ jobs:
         key: ${{ runner.os }}-poetry-${{ hashFiles(format('{0}{1}', github.workspace, '/poetry.lock')) }}
         restore-keys: |
           ${{ runner.os }}-poetry-
-    - name: Install dependencies (allow "failures" and attempt to continue)
+    - name: Install dependencies
       run: |
         pip install poetry
-        poetry install -vv --no-root --no-interaction
+        poetry install -vv --no-interaction
         poetry show -vv
     - name: Build docs
       run: AUDIT_SERVICE_CONFIG_PATH=src/audit/config-default.yaml poetry run python run.py openapi


### PR DESCRIPTION
Stop using the old poetry installer to fix this error:

> \> Run curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
Retrieving Poetry metadata
This installer is deprecated, and scheduled for removal from the Poetry repository on or after January 1, 2023.
[...]

### Improvements
- Use pip to install poetry in CI
