### PR TITLE
Fix docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Skip for docs-only changes
       run: |
         git fetch -q
-        CHANGED=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep -v '@' || true)
+        CHANGED=$(git diff --name-only HEAD^1 HEAD | grep -v '@' || true)
         echo "Changed files:"
         echo "$CHANGED"
         if [ -z "$CHANGED" ]; then


### PR DESCRIPTION
Fix docs workflow: when checking whether to skip the docs update, it should check the changes in the last commit, not the whole branch